### PR TITLE
Send the Content-Disposition header to clients

### DIFF
--- a/src/liiteri/api.clj
+++ b/src/liiteri/api.clj
@@ -71,9 +71,10 @@
               :summary "Download a file"
               :path-params [key :- (api/describe s/Str "Key of the file")]
               (if-let [file-response (file-store/get-file key storage-engine db)]
-                (response/header (response/ok (:body file-response))
-                               "Content-Disposition"
-                               (str "attachment; filename=\"" (:filename file-response) "\""))
+                (-> (response/ok (:body file-response))
+                    (response/header
+                      "Content-Disposition"
+                      (str "attachment; filename=\"" (:filename file-response) "\"")))
                 (response/not-found)))
 
             (api/DELETE "/files/:key" []

--- a/src/liiteri/api.clj
+++ b/src/liiteri/api.clj
@@ -64,8 +64,10 @@
           (api/GET "/files/:key" []
             :summary "Download a file"
             :path-params [key :- (api/describe s/Str "Key of the file")]
-            (if-let [file-stream (file-store/get-file key storage-engine db)]
-              (response/ok file-stream)
+            (if-let [file-response (file-store/get-file key storage-engine db)]
+              (response/header (response/ok (:body file-response))
+                               "Content-Disposition"
+                               (str "attachment; filename=\"" (:filename file-response) "\""))
               (response/not-found)))
 
           (api/DELETE "/files/:key" []

--- a/src/liiteri/files/file_store.clj
+++ b/src/liiteri/files/file_store.clj
@@ -29,4 +29,5 @@
 (defn get-file [key storage-engine db]
   (let [metadata (metadata-store/get-metadata key db)]
     (when (> (count metadata) 0)
-      (.get-file storage-engine key))))
+      {:body (.get-file storage-engine key)
+       :filename (:filename (first metadata))})))


### PR DESCRIPTION
This allows clients to get the filename and download functionality in browsers along with the file itself.