### PR TITLE
Fix master: Remove preconditions from method

### DIFF
--- a/src/liiteri/audit_log.clj
+++ b/src/liiteri/audit_log.clj
@@ -29,12 +29,6 @@
   AuditLog
 
   (log [this id operation message]
-    {:pre [(or (and (string? id)
-                    (not-blank? id))
-               (and (vector? id)
-                    (every? not-blank? id)))
-           (some #{operation} [operation-new operation-delete operation-query])
-           (some? message)]}
     (let [logger    (:logger this)
           timestamp (f/unparse date-time-formatter (t/now))
           id-map    {:file-keys (if (string? id) [id] id)}


### PR DESCRIPTION
It looks like the preconditions on a method are never used, at least according to Eastwood. This keeps the master build red. Removing the preconditions fixes this.