### PR TITLE
Emit an audit log on a failed upload

### DIFF
--- a/src/liiteri/api.clj
+++ b/src/liiteri/api.clj
@@ -61,7 +61,7 @@
                 (catch Exception e
                   (let [error (ex-data e)]
                     (.log audit-logger "" audit-log/operation-new (:response error))
-                    (ring.util.http-response/bad-request! (-> error :response :body))))
+                    (response/bad-request! (-> error :response :body))))
                 (finally
                   (io/delete-file (:tempfile file) true))))
 

--- a/src/liiteri/api.clj
+++ b/src/liiteri/api.clj
@@ -58,6 +58,10 @@
                       {:keys [key] :as resp} (file-store/create-file (assoc file :filename fixed-filename) storage-engine db)]
                   (.log audit-logger key audit-log/operation-new resp)
                   (response/ok resp))
+                (catch Exception e
+                  (let [error (ex-data e)]
+                    (.log audit-logger "" audit-log/operation-new (:response error))
+                    (ring.util.http-response/bad-request! (-> error :response :body))))
                 (finally
                   (io/delete-file (:tempfile file) true))))
 


### PR DESCRIPTION
The id here is empty because we don't have a key at hand.