### PR TITLE
Revert "Fix metadata check"

### DIFF
--- a/src/liiteri/db/file_metadata_store.clj
+++ b/src/liiteri/db/file_metadata_store.clj
@@ -31,8 +31,7 @@
                          (t/before? (get-in result [key :uploaded]) uploaded))
                      (assoc key metadata)))
                  {})
-         (map second)
-         (first))))
+         (map second))))
 
 (defn get-unscanned-file [conn]
   (->> (sql-get-unscanned-file {} conn)


### PR DESCRIPTION
Reverts Opetushallitus/liiteri#24

This fix breaks the metadata endpoint