### PR TITLE
Fix middleware

### DIFF
--- a/dev-resources/dev-config.edn
+++ b/dev-resources/dev-config.edn
@@ -23,4 +23,4 @@
  :antivirus {:clamav-url            "http://tentti.hard.ware.fi:8765"
              :mock? false
              :poll-interval-seconds 5}
- :file-cleaner {:poll-interval-seconds 10}}
+ :file-cleaner {:poll-interval-seconds 100}}

--- a/dev-resources/local-test-config.edn
+++ b/dev-resources/local-test-config.edn
@@ -23,4 +23,4 @@
  :antivirus {:clamav-url            "http://localhost:8765"
              :mock?                 true
              :poll-interval-seconds 5}
- :file-cleaner {:poll-interval-seconds 10}}
+ :file-cleaner {:poll-interval-seconds 100}}

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
                  [camel-snake-kebab "0.4.0"]
                  [cheshire "5.7.1"]
                  [clj-time "0.13.0"]
-                 [metosin/compojure-api "1.1.10"]
+                 [metosin/compojure-api "1.2.0-alpha5"]
                  [com.stuartsierra/component "0.3.2"]
                  [org.flywaydb/flyway-core "4.1.2"]
                  [fi.vm.sade/auditlogger "5.0.0-SNAPSHOT"]

--- a/src/liiteri/api.clj
+++ b/src/liiteri/api.clj
@@ -75,7 +75,7 @@
 
             (api/POST "/files/finalize" []
               :summary "Finalize one or more files"
-              :query-params [keys :- [s/Str]]
+              :body-params [keys :- [s/Str]]
               (.log audit-logger keys audit-log/operation-finalize {})
               (file-metadata-store/finalize-files keys db)
               (response/ok))

--- a/test/liiteri/api_test.clj
+++ b/test/liiteri/api_test.clj
@@ -44,8 +44,9 @@
       (is (= (:size saved-metadata) 7777))
       (is (nil? (:deleted saved-metadata)))
       (is (= "not_started" (:virus-scan-status saved-metadata))))
-    (let [resp           @(http/post (str path "/finalize")
-                                     {:query-params {:keys [(:key body)]}})
+    (let [_              @(http/post (str path "/finalize")
+                                     {:headers {"Content-Type" "application/json"}
+                                      :body    (json/generate-string {:keys [(:key body)]})})
           saved-metadata (metadata/get-metadata-for-tests [(:key body)] (:db @system))]
       (is (= (:final saved-metadata) true)))))
 


### PR DESCRIPTION
Version 1.10.0 of compojure-api has a bug where it applies every middleware to every request, regardless of endpoint. Version 1.2.0-alpha5 has fixed this issue (although it still does establish the middleware three times when it should do it only once, but that's a minor issue). 

If we're brave enough, this PR upgrades compojure-api to the next alpha. I've verified it no longer calls the multipart middleware on every request.

- [x] Fix query/body parameter mismatch. This was necessary because the newer version of compojure-api no longer apparently accepts empty POST bodies.