### PR TITLE
Unicode normalize filenames when they come in

### DIFF
--- a/src/liiteri/db/file_metadata_store.clj
+++ b/src/liiteri/db/file_metadata_store.clj
@@ -4,7 +4,8 @@
             [liiteri.schema :as schema]
             [schema-tools.core :as st]
             [yesql.core :as sql])
-  (:import [org.joda.time DateTime]))
+  (:import [org.joda.time DateTime]
+           (java.text Normalizer Normalizer$Form)))
 
 (sql/defqueries "sql/files.sql")
 
@@ -22,27 +23,36 @@
 (def ^:private non-valid-character-pattern #"(?i)[^a-z\.\-_0-9 ]")
 (def ^:private empty-filename-pattern #"(?i)^\.([a-z0-9]+)$")
 
-(defn- normalize [string]
-  (let [normalized (-> string
-                       (clojure.string/replace #"ä" "a")
-                       (clojure.string/replace #"Ä" "A")
-                       (clojure.string/replace #"ö" "o")
-                       (clojure.string/replace #"Ö" "O")
-                       (clojure.string/replace #"å" "a")
-                       (clojure.string/replace #"Å" "a")
-                       (clojure.string/replace non-valid-character-pattern ""))
-        matcher    (re-matcher empty-filename-pattern normalized)
-        extension  (second (re-find matcher))]
+(defn- sanitize [string]
+  (let [sanitized (-> string
+                      (clojure.string/replace #"ä" "a")
+                      (clojure.string/replace #"Ä" "A")
+                      (clojure.string/replace #"ö" "o")
+                      (clojure.string/replace #"Ö" "O")
+                      (clojure.string/replace #"å" "a")
+                      (clojure.string/replace #"Å" "a")
+                      (clojure.string/replace non-valid-character-pattern ""))
+        matcher   (re-matcher empty-filename-pattern sanitized)
+        extension (second (re-find matcher))]
     (if (empty? extension)
-      normalized
+      sanitized
       (str "liite." extension))))
+
+(defn- unicode-normalize
+  "Normalize given string to Unicode Normalization Form C (NFC), which uses
+  canonical decomposition and then canonical composition. See
+  <http://www.unicode.org/reports/tr15/tr15-23.html> for more information
+  on Unicode Normalization Forms."
+  [s]
+  (Normalizer/normalize s Normalizer$Form/NFC))
 
 (defn create-file [spec db]
   (with-db [conn db]
     (-> (db-utils/kwd->snake-case spec)
+        (update :filename unicode-normalize)
         (sql-create-file<! conn)
         (db-utils/unwrap-data)
-        (update :filename normalize)
+        (update :filename sanitize)
         (dissoc :id))))
 
 (defn delete-file [key db]
@@ -53,7 +63,7 @@
   (with-db [conn db]
     (->> (sql-get-metadata {:keys key-list} conn)
          (eduction (map db-utils/unwrap-data)
-                   (map #(update % :filename normalize)))
+                   (map #(update % :filename sanitize)))
          (reduce (fn pick-latest-metadata [result {:keys [key uploaded] :as metadata}]
                    (cond-> result
                      (or (not (contains? result key))
@@ -67,7 +77,7 @@
          (contains? conn :connection)]} ; force transaction
   (->> (sql-get-unscanned-file {} conn)
        (eduction (map db-utils/unwrap-data)
-                 (map #(update % :filename normalize)))
+                 (map #(update % :filename sanitize)))
        (first)))
 
 (defn get-old-draft-files [db]

--- a/test/liiteri/file_metadata_store_test.clj
+++ b/test/liiteri/file_metadata_store_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [liiteri.db.file-metadata-store :as metadata-store]))
 
-(deftest normalize-filename
+(deftest sanitize-filename
   (doseq [[filename expected] [["parrot.png" "parrot.png"]
                                ["parrot..png" "parrot..png"]
                                ["parrot/:;.png" "parrot.png"]
@@ -12,6 +12,13 @@
                                ["pärrötå.png" "parrota.png"]
                                ["parrot🍺.png" "parrot.png"]
                                [":::.png" "liite.png"]
+                               ["nfd-ä.png" "nfd-a.png"]
                                [".png" "liite.png"]]]
-    (let [actual (#'metadata-store/normalize filename)]
+    (let [actual (#'metadata-store/sanitize filename)]
+      (is (= expected actual)))))
+
+(deftest unicode-normalize-filename
+  (doseq [[filename expected] [["nfd-ä.png" "nfd-ä.png"]
+                               ["nfc-ä.png" "nfc-ä.png"]]]
+    (let [actual (#'metadata-store/unicode-normalize filename)]
       (is (= expected actual)))))


### PR DESCRIPTION
This saves us trouble when sanitising filenames.