### PR TITLE
Käytä openjdk8:aa travis-buildissä

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 language: generic
+jdk:
+  - openjdk8
 services:
   - docker
 env:


### PR DESCRIPTION
Aiemmin traviksen jdk-asetus ei ole ollut eksplisiittisesti
määritetty, ilmeisesti on käyttänyt defaulttina Oracle JDK 8:aa.