### PR TITLE
HLE-1185: liitteiden tiedostonnimen normalisointi

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,8 @@
                  [org.apache.pdfbox/pdfbox "2.0.17"]
                  [com.github.jai-imageio/jai-imageio-core "1.3.1"]
                  [com.github.jai-imageio/jai-imageio-jpeg2000 "1.3.0"]
-                 [com.levigo.jbig2/levigo-jbig2-imageio "2.0"]]
+                 [com.levigo.jbig2/levigo-jbig2-imageio "2.0"]
+                 [oph/clj-string-normalizer "0.1.0-SNAPSHOT"]]
 
   :repositories [["snapshots" {:url "https://artifactory.opintopolku.fi/artifactory/oph-sade-snapshot-local"}]]
 

--- a/resources/sql/files.sql
+++ b/resources/sql/files.sql
@@ -121,3 +121,6 @@ FROM files
 WHERE virus_scan_status = 'not_started' AND deleted IS NULL
 ORDER BY age(uploaded) DESC
 LIMIT 1;
+
+-- name: sql-update-filename!
+UPDATE files SET filename = :filename WHERE key = :file_key;

--- a/src/liiteri/api.clj
+++ b/src/liiteri/api.clj
@@ -99,7 +99,7 @@
                      :header-params [{x-real-ip :- s/Str nil}
                                      {user-agent :- s/Str nil}]
                      :return [schema/File]
-                     (let [metadata (file-metadata-store/get-metadata key {:connection db})]
+                     (let [metadata (file-metadata-store/get-normalized-metadata! key {:connection db})]
                        (if (> (count metadata) 0)
                          (do (doseq [{:keys [key]} metadata]
                                (audit-log/log audit-logger
@@ -116,7 +116,7 @@
                      :header-params [{x-real-ip :- s/Str nil}
                                      {user-agent :- s/Str nil}]
                      :return [schema/File]
-                     (let [metadata (file-metadata-store/get-metadata keys {:connection db})]
+                     (let [metadata (file-metadata-store/get-normalized-metadata! keys {:connection db})]
                        (if (= (count metadata) (count keys))
                          (do (doseq [{:keys [key]} metadata]
                                (audit-log/log audit-logger
@@ -132,7 +132,7 @@
                      :header-params [{x-real-ip :- s/Str nil}
                                      {user-agent :- s/Str nil}]
                      :path-params [key :- (api/describe s/Str "Key of the file")]
-                     (let [[metadata] (file-metadata-store/get-metadata [key] {:connection db})]
+                     (let [[metadata] (file-metadata-store/get-normalized-metadata! [key] {:connection db})]
                        (if (= "done" (:virus-scan-status metadata))
                          (if-let [file-response (file-store/get-file-and-metadata key storage-engine {:connection db})]
                            (do (audit-log/log audit-logger

--- a/src/liiteri/files/file_store.clj
+++ b/src/liiteri/files/file_store.clj
@@ -33,7 +33,7 @@
     deleted))
 
 (defn get-file-and-metadata [key storage-engine conn]
-  (let [metadata (metadata-store/get-metadata [key] conn)]
+  (let [metadata (metadata-store/get-normalized-metadata! [key] conn)]
     (when (> (count metadata) 0)
       {:body     (.get-file storage-engine key)
        :filename (:filename (first metadata))})))

--- a/test/liiteri/api_test.clj
+++ b/test/liiteri/api_test.clj
@@ -29,10 +29,10 @@
     (.exists file)))
 
 (deftest file-upload
-  (doseq [[filename file content-type size] ok-files]
+  (doseq [{:keys [filename file-object content-type size]} ok-files]
     (log/info (format "Testing normal file upload for filename %s with content-type %s, size %d (should pass)" filename content-type size))
     (let [path (str "http://localhost:" (get-in config [:server :port]) "/liiteri/api/files")
-          resp @(http/post path {:multipart [{:name "file" :content file :filename filename :content-type content-type}]})
+          resp @(http/post path {:multipart [{:name "file" :content file-object :filename filename :content-type content-type}]})
           body (json/parse-string (:body resp) true)]
       (is (= (:status resp) 200))
       (is (file-stored? (:key body)))
@@ -57,14 +57,14 @@
         (is (= (json/parse-string (:body delete-resp) true) {:key (:key body)}))))))
 
 (deftest mangled-extensions
-  (doseq [[mangled-filename filename file content-type size] mangled-extension-files]
+  (doseq [{:keys [mangled-filename filename file-object content-type size]} mangled-extension-files]
     (log/info (format "Testing extension repairing for filename %s -> %s with content-type %s, size %d (should pass)"
                       mangled-filename
                       filename
                       content-type
                       size))
     (let [path (str "http://localhost:" (get-in config [:server :port]) "/liiteri/api/files")
-          resp @(http/post path {:multipart [{:name "file" :content file :filename mangled-filename :content-type content-type}]})
+          resp @(http/post path {:multipart [{:name "file" :content file-object :filename mangled-filename :content-type content-type}]})
           body (json/parse-string (:body resp) true)]
       (is (= (:status resp) 200))
       (is (file-stored? (:key body)))
@@ -89,10 +89,10 @@
         (is (= (json/parse-string (:body delete-resp) true) {:key (:key body)}))))))
 
 (deftest forbidden-files-refused
-  (doseq [[filename file content-type size] forbidden-files]
+  (doseq [{:keys [filename file-object content-type size]} forbidden-files]
     (log/info (format "Testing %s with content-type %s, size %d (should fail)" filename content-type size))
     (let [path (str "http://localhost:" (get-in config [:server :port]) "/liiteri/api/files")
-          resp @(http/post path {:multipart [{:name "file" :content file :filename filename :content-type content-type}]})
+          resp @(http/post path {:multipart [{:name "file" :content file-object :filename filename :content-type content-type}]})
           body (json/parse-string (:body resp) true)]
       (is (= (:status resp) 400))
       (is (nil? body))

--- a/test/liiteri/fixtures.clj
+++ b/test/liiteri/fixtures.clj
@@ -1,12 +1,15 @@
 (ns liiteri.fixtures
   (:require [clojure.java.io :as io]))
 
-(defn load-test-file [filename content-type]
+(defn load-test-file [{:keys [filename content-type]}]
   (let [file-object (io/file (io/resource (format "test-files/%s" filename)))]
-    [filename file-object content-type (.length file-object)]))
+    {:filename     filename
+     :file-object  file-object
+     :content-type content-type
+     :size         (.length file-object)}))
 
-(defn load-mangled-extension-test-file [mangled-filename filename content-type]
-  (concat [mangled-filename] (load-test-file filename content-type)))
+(defn load-mangled-extension-test-file [{:keys [mangled-filename filename content-type]}]
+  (assoc (load-test-file {:filename filename :content-type content-type}) :mangled-filename mangled-filename))
 
 (def file-types
   {:exe  "application/octet-stream"
@@ -23,26 +26,26 @@
    :xls  "application/vnd.ms-excel"
    :xlsx "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"})
 
-(def forbidden-files [(load-test-file "sample.exe" (:exe file-types))])
+(def forbidden-files [(load-test-file {:filename "sample.exe" :content-type (:exe file-types)})])
 
-(def ok-files [(load-test-file "sample.doc" (:doc file-types))
-               (load-test-file "sample.docx" (:docx file-types))
-               (load-test-file "sample.jpg" (:jpg file-types))
-               (load-test-file "sample.ods" (:ods file-types))
-               (load-test-file "sample.odt" (:odt file-types))
-               (load-test-file "sample.pdf" (:pdf file-types))
-               (load-test-file "sample.png" (:png file-types))
-               (load-test-file "sample.txt" (:txt file-types))
-               (load-test-file "sample.xls" (:xls file-types))
-               (load-test-file "sample.xlsx" (:xlsx file-types))])
+(def ok-files [(load-test-file {:filename "sample.doc" :content-type (:doc file-types)})
+               (load-test-file {:filename "sample.docx" :content-type (:docx file-types)})
+               (load-test-file {:filename "sample.jpg" :content-type (:jpg file-types)})
+               (load-test-file {:filename "sample.ods" :content-type (:ods file-types)})
+               (load-test-file {:filename "sample.odt" :content-type (:odt file-types)})
+               (load-test-file {:filename "sample.pdf" :content-type (:pdf file-types)})
+               (load-test-file {:filename "sample.png" :content-type (:png file-types)})
+               (load-test-file {:filename "sample.txt" :content-type (:txt file-types)})
+               (load-test-file {:filename "sample.xls" :content-type (:xls file-types)})
+               (load-test-file {:filename "sample.xlsx" :content-type (:xlsx file-types)})])
 
-(def mangled-extension-files [(load-mangled-extension-test-file "sample.docx" "sample.doc" (:doc file-types))
-                              (load-mangled-extension-test-file "sample.doc" "sample.docx" (:docx file-types))
-                              (load-mangled-extension-test-file "sample.png" "sample.jpg" (:jpg file-types))
-                              (load-mangled-extension-test-file "sample.xls" "sample.ods" (:ods file-types))
-                              (load-mangled-extension-test-file "sample.doc" "sample.odt" (:odt file-types))
-                              (load-mangled-extension-test-file "sample.doc" "sample.pdf" (:pdf file-types))
-                              (load-mangled-extension-test-file "sample.jpg" "sample.png" (:png file-types))
-                              (load-mangled-extension-test-file "sample.doc" "sample.txt" (:txt file-types))
-                              (load-mangled-extension-test-file "sample.odt" "sample.xls" (:xls file-types))
-                              (load-mangled-extension-test-file "sample.xls" "sample.xlsx" (:xlsx file-types))])
+(def mangled-extension-files [(load-mangled-extension-test-file {:mangled-filename "sample.docx" :filename "sample.doc" :content-type (:doc file-types)})
+                              (load-mangled-extension-test-file {:mangled-filename "sample.doc" :filename "sample.docx" :content-type (:docx file-types)})
+                              (load-mangled-extension-test-file {:mangled-filename "sample.png" :filename "sample.jpg" :content-type (:jpg file-types)})
+                              (load-mangled-extension-test-file {:mangled-filename "sample.xls" :filename "sample.ods" :content-type (:ods file-types)})
+                              (load-mangled-extension-test-file {:mangled-filename "sample.doc" :filename "sample.odt" :content-type (:odt file-types)})
+                              (load-mangled-extension-test-file {:mangled-filename "sample.doc" :filename "sample.pdf" :content-type (:pdf file-types)})
+                              (load-mangled-extension-test-file {:mangled-filename "sample.jpg" :filename "sample.png" :content-type (:png file-types)})
+                              (load-mangled-extension-test-file {:mangled-filename "sample.doc" :filename "sample.txt" :content-type (:txt file-types)})
+                              (load-mangled-extension-test-file {:mangled-filename "sample.odt" :filename "sample.xls" :content-type (:xls file-types)})
+                              (load-mangled-extension-test-file {:mangled-filename "sample.xls" :filename "sample.xlsx" :content-type (:xlsx file-types)})])

--- a/test/liiteri/mime_fixer_test.clj
+++ b/test/liiteri/mime_fixer_test.clj
@@ -25,7 +25,7 @@
 (deftest mime-fixer-ok-files
   (let [store (u/new-in-memory-store)
         conn  {:connection (:db @system)}]
-    (doseq [[mangled-filename filename file content-type size] mangled-extension-files]
+    (doseq [{:keys [mangled-filename filename file-object content-type size]} mangled-extension-files]
       (let [uploaded  (-> (t/now)
                           (.getMillis)
                           (Timestamp.))
@@ -35,7 +35,7 @@
                        :size         size
                        :uploaded     uploaded}]
         (metadata-store/create-file file-spec conn)
-        (file-store/create-file store file filename)
+        (file-store/create-file store file-object filename)
         (mime-fixer/fix-mime-type-of-file conn store {:key      filename
                                                       :filename mangled-filename
                                                       :uploaded uploaded})

--- a/test/liiteri/mime_test.clj
+++ b/test/liiteri/mime_test.clj
@@ -8,13 +8,13 @@
 (def config (config/new-config))
 
 (deftest ok-mime-type-allowed
-  (doseq [[name _ content-type] ok-files]
+  (doseq [{:keys [name content-type]} ok-files]
     (do
       (log/info (format "Testing %s with content-type %s (should pass)" name content-type))
       (mime/validate-file-content-type! config name content-type content-type))))
 
 (deftest forbidden-mime-type-rejected
-  (doseq [[name _ content-type] forbidden-files]
+  (doseq [{:keys [name content-type]} forbidden-files]
     (do
       (log/info (format "Testing %s with content-type %s (should throw exception)" name content-type))
       (is (thrown? clojure.lang.ExceptionInfo (mime/validate-file-content-type! config name content-type content-type))))))

--- a/test/liiteri/preview/preview_generator_test.clj
+++ b/test/liiteri/preview/preview_generator_test.clj
@@ -43,7 +43,7 @@
 (deftest previews-are-generated-for-pdf-files
   (let [store (u/new-in-memory-store)
         conn  {:connection (:db @system)}]
-    (doseq [[filename file content-type size] fixtures/ok-files]
+    (doseq [{:keys [filename file-object content-type size]} fixtures/ok-files]
       (let [uploaded  (-> (t/now)
                           (.getMillis)
                           (Timestamp.))
@@ -53,7 +53,7 @@
                        :size         size
                        :uploaded     uploaded}]
         (test-metadata-store/create-file file-spec conn)
-        (file-store/create-file store file filename)
+        (file-store/create-file store file-object filename)
         (metadata-store/set-virus-scan-status! filename "done" conn)
         (metadata-store/finalize-files [filename] conn)
         (preview-generator/generate-file-previews (:config @system) conn store file-spec)
@@ -67,7 +67,7 @@
 (deftest previews-are-deleted-when-file-is-deleted
   (let [store (u/new-in-memory-store)
         conn  {:connection (:db @system)}]
-    (doseq [[filename file content-type size] (take 2 fixtures/ok-files)]
+    (doseq [{:keys [filename file-object content-type size]} (take 2 fixtures/ok-files)]
       (let [uploaded  (-> (t/now)
                           (.getMillis)
                           (Timestamp.))
@@ -77,7 +77,7 @@
                        :size         size
                        :uploaded     uploaded}]
         (test-metadata-store/create-file file-spec conn)
-        (file-store/create-file store file filename)
+        (file-store/create-file store file-object filename)
         (metadata-store/set-virus-scan-status! filename "done" conn)
         (metadata-store/finalize-files [filename] conn)
         (preview-generator/generate-file-previews (:config @system) conn store file-spec)

--- a/test/liiteri/preview/preview_generator_test.clj
+++ b/test/liiteri/preview/preview_generator_test.clj
@@ -58,7 +58,7 @@
         (metadata-store/finalize-files [filename] conn)
         (preview-generator/generate-file-previews (:config @system) conn store file-spec)
 
-        (let [file-metadata-after-preview (first (metadata-store/get-metadata [filename] conn))
+        (let [file-metadata-after-preview (first (metadata-store/get-normalized-metadata! [filename] conn))
               generated-previews          (vec (metadata-store/get-previews filename conn))]
           (if (= "application/pdf" content-type)
             (assert-has-single-png-preview-page file-metadata-after-preview generated-previews)
@@ -84,7 +84,7 @@
 
         (file-store/delete-file-and-metadata (:key file-spec) store conn)
 
-        (let [file-metadata-after-preview (first (metadata-store/get-metadata [filename] conn))
+        (let [file-metadata-after-preview (first (metadata-store/get-normalized-metadata! [filename] conn))
               generated-previews          (vec (metadata-store/get-previews filename conn))]
           (is (= 0 (count generated-previews)))
           (is (= nil file-metadata-after-preview)))))))


### PR DESCRIPTION
Tähän liittyvät pull requestit: https://github.com/Opetushallitus/ataru/pull/1009 ja https://github.com/Opetushallitus/clj-util/pull/7

Normalisoidaan tiedostonnimet tietokantaan asti haettaessa tiedostoja Liiteristä. Tähän laiskaan ratkaisuun päädyttiin sen vuoksi, että migraatio olisi saattanut olla liian raskas ja sen ajo olisi blokannut Liiterin käynnistämistä. Migraatio on luonnollisesti mahdollinen toteuttaa myöhemminkin. Tietokantaan ei tehdä 

Lopputuloksena kaikki Liiteristä ladatut tiedostot tarjoillaan ns. normalisoidulla tiedostonnimellä, jolloin esim. zip-paketin avaamisen Windowsilla pitäisi onnistua.

Alla esimerkki normalisoijan tekemästä logimerkinnästä:

```
2020-04-14 09:48:16 +0300 INFO [liiteri.files.filename-normalizer:43] - Normalized filename, file key: fea9a78c-800b-484b-8870-3735e53a4c02, old filename: åöäå¨ä��äaser.txt, normalized filename: aoaaaaaser.txt
```