### PR TITLE
Oy 4808 finalisointipurske jumittaa skannaustulokset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       application: liiteri
       base-image: baseimage-fatjar-openjdk11:master
       configfolder: oph-configuration
-      jarfile: liiteri.jar
+      jarfile: liiteri
       jarfolder: target
     secrets:
       AWS_UTILITY_ROLE_ARN: ${{ secrets.AWS_OPH_UTILITY_ROLE_ARN }}

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ JVM system properties on startup.
 
 ## Testing
 
-Tests require own separate database. You can start it with Docker by hand
+Tests require own separate database and Localstack. You can start them with Docker by hand
 
 ```bash
-$ docker run --name liiteri-test-db -e POSTGRES_PASSWORD=oph -e POSTGRES_USER=oph -e POSTGRES_DB=liiteri -p 5435:5432 -d postgres:11
+$ docker-compose up -d
 ```
 
 and then run tests once by invoking

--- a/src/liiteri/api.clj
+++ b/src/liiteri/api.clj
@@ -97,10 +97,10 @@
       :body-params [keys :- [s/Str]]
       (check-authorization! session)
       (when (> (count keys) 0)
-        (file-metadata-store/finalize-files keys origin-system origin-reference {:connection db})
         (let [metadata (file-metadata-store/get-metadata keys {:connection db})]
-          (doseq [{key :key filename :filename content-type :content-type} metadata]
-            (virus-scan/request-file-scan virus-scan key filename content-type)
+          (file-metadata-store/finalize-files keys origin-system origin-reference {:connection db})
+          (virus-scan/request-file-scan virus-scan (filter (fn [item] (not (:final item))) metadata))
+          (doseq [{key :key} metadata]
             (audit-log/log audit-logger
                            (audit-log/user session x-real-ip user-agent)
                            audit-log/operation-finalize

--- a/src/liiteri/core.clj
+++ b/src/liiteri/core.clj
@@ -16,7 +16,6 @@
             [taoensso.timbre :as log]
             [taoensso.timbre.appenders.3rd-party.rolling :refer [rolling-appender]]
             [timbre-ns-pattern-level :as pattern-level]
-            [liiteri.sqs-client :as sqs-client]
             [liiteri.local :as local])
   (:import [java.util TimeZone])
   (:gen-class))
@@ -62,7 +61,7 @@
 
            :virus-scan (component/using
                          (virus-scan/new-scanner)
-                         [:db :storage-engine :config :migrations :sqs-client])
+                         [:db :storage-engine :config :migrations])
 
            :file-cleaner (component/using
                            (file-cleaner/new-cleaner false)
@@ -80,8 +79,6 @@
                                 (preview-generator/new-preview-generator)
                                 [:db :storage-engine :config :migrations])
 
-           :sqs-client (component/using (sqs-client/new-client) [:config])
-
            :s3-client (component/using
                         (s3-client/new-client)
                         [:config])
@@ -90,7 +87,7 @@
                              (s3-store/new-store)
                              [:s3-client :config])
 
-           :local (component/using (local/new-local) [:config :sqs-client :s3-client]))))
+           :local (component/using (local/new-local) [:config :s3-client]))))
 
 (defn -main [& _]
   (let [_ (component/start-system (new-system))]

--- a/src/liiteri/sqs_client.clj
+++ b/src/liiteri/sqs_client.clj
@@ -1,6 +1,5 @@
 (ns liiteri.sqs-client
-  (:require [com.stuartsierra.component :as component]
-            [environ.core :refer [env]])
+  (:require [environ.core :refer [env]])
   (:import [com.amazonaws.services.sqs AmazonSQSClient]
            [com.amazonaws.client.builder AwsClientBuilder$EndpointConfiguration]
            [com.amazonaws.auth DefaultAWSCredentialsProviderChain]
@@ -14,22 +13,12 @@
   {:access-key (env :aws-access-key)
    :secret-key (env :aws-secret-key)})
 
-(defrecord SQSClient [config]
-  component/Lifecycle
-
-  (start [this]
-    (assoc this :sqs-client
-                (if (dev?)
-                  (-> (AmazonSQSClient/builder)
-                      (.withEndpointConfiguration (AwsClientBuilder$EndpointConfiguration. "http://localhost:4566" "us-east-1"))
-                      (.withCredentials (AWSStaticCredentialsProvider. (BasicAWSCredentials. (:access-key aws-credentials) (:secret-key aws-credentials))))
-                      (.build))
-                  (-> (AmazonSQSClient/builder)
-                      (.withCredentials (DefaultAWSCredentialsProviderChain/getInstance))
-                      (.build)))))
-
-  (stop [this]
-    (assoc this :sqs-client nil)))
-
-(defn new-client []
-  (map->SQSClient {}))
+(defn get-sqs-client []
+  (if (dev?)
+    (-> (AmazonSQSClient/builder)
+        (.withEndpointConfiguration (AwsClientBuilder$EndpointConfiguration. "http://localhost:4566" "us-east-1"))
+        (.withCredentials (AWSStaticCredentialsProvider. (BasicAWSCredentials. (:access-key aws-credentials) (:secret-key aws-credentials))))
+        (.build))
+    (-> (AmazonSQSClient/builder)
+        (.withCredentials (DefaultAWSCredentialsProviderChain/getInstance))
+        (.build))))

--- a/test/liiteri/virus_scan_test.clj
+++ b/test/liiteri/virus_scan_test.clj
@@ -61,7 +61,7 @@
         get-metadata #(test-metadata-store/get-metadata-for-tests [(:key @metadata)] {:connection db})
         {:keys [key filename content-type]} (get-metadata)
         store (:storage-engine @system)]
-    (virus-scan/request-file-scan virus-scan key filename content-type)
+    (virus-scan/request-file-scan virus-scan [{:key key :filename filename :content-type content-type}])
     (wait-for-status "done" get-metadata)
     (is (file-store/file-exists? store key))))
 
@@ -71,7 +71,7 @@
         get-metadata #(test-metadata-store/get-metadata-for-tests [(:key @metadata)] {:connection db})
         {:keys [key content-type]} (get-metadata)
         store (:storage-engine @system)]
-    (virus-scan/request-file-scan virus-scan key "eicar" content-type)
+    (virus-scan/request-file-scan virus-scan [{:key key :filename "eicar" :content-type content-type}])
     (wait-for-status "virus_found" get-metadata)
     ; objects that fail virus scan get deleted
     (is (not (file-store/file-exists? store key)))))


### PR DESCRIPTION
- Eriytetty skannauspyyntöjen ja tulosten prosessoinnin sqs-clientit joten pyyntöjen määrän ei pitäisi enää jumiuttaa tulosten prosessointia
- Lähetetään koko finalisointisatsin pyynnöt yhdellä kutsulla