### PR TITLE
OY-5023 Preview-generointi kaatumislooppi

### DIFF
--- a/resources/migrations/V20241217160000__add_started_preview_status.sql
+++ b/resources/migrations/V20241217160000__add_started_preview_status.sql
@@ -1,0 +1,1 @@
+ALTER TYPE preview_generation_status ADD VALUE 'started' AFTER 'not_generated';

--- a/src/liiteri/preview/preview_generator.clj
+++ b/src/liiteri/preview/preview_generator.clj
@@ -31,6 +31,9 @@
          uploaded :uploaded} file]
     (try
       (log/info (format "Generating previews for '%s' with key '%s', uploaded on %s ..." filename file-key uploaded))
+      ; Tämä on varotoimenpide tapauksille joissa generointi kaataa JVM:än. Ilman tilan päivitystä generointia yritään
+      ; aina uudestaan samoin (huonoin) tuloksin koska tiedosto on edelleen not started -tilassa.
+      (metadata-store/set-file-page-count-and-preview-status! file-key nil "started" conn)
       (with-open [input-stream (file-store/get-file storage-engine file-key)]
         (let [preview-timeout-ms    (get-in config [:preview-generator :preview-timeout-ms] 45000)
               [page-count previews] (.invokeAny timeout-scheduler [#(try

--- a/src/liiteri/schema.clj
+++ b/src/liiteri/schema.clj
@@ -22,6 +22,6 @@
    :final             s/Bool
    :uploaded          DateTime
    :deleted           (s/maybe DateTime)
-   :preview-status    (s/enum "not_supported" "not_generated" "finished" "error")
+   :preview-status    (s/enum "not_supported" "not_generated" "started" "finished" "error")
    :previews          [Preview]
    (s/optional-key :content-disposition) (s/maybe s/Str)})


### PR DESCRIPTION
  Aikaisemmin tiedoston preview-generoinnin tilaa muutettiin vasta kun generointia oli yritetty.
  Tästä seurasi että mikäli generointi kaatoi JVM:än sitä yritettiin aina uudestaan samoin
  tuloksin. Nyt lisätty generointiin uusi tila started jolloin sitä ei käynnistetä enää uudestaan.