### PR TITLE
OY-5483 Joda-timen vaihto java-timeen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>liiteri</groupId>
   <artifactId>liiteri</artifactId>
@@ -18,7 +18,7 @@
     <url>https://github.com/Opetushallitus/liiteri</url>
     <connection>scm:git:git://github.com/Opetushallitus/liiteri.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Opetushallitus/liiteri.git</developerConnection>
-    <tag>9d17b085e6c13cfa82d8dd6264249c1e329eeae3</tag>
+    <tag>e5de29591220ef18eed692cfef665345633006c1</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -179,11 +179,6 @@
       <groupId>cheshire</groupId>
       <artifactId>cheshire</artifactId>
       <version>6.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>clj-time</groupId>
-      <artifactId>clj-time</artifactId>
-      <version>0.15.2</version>
     </dependency>
     <dependency>
       <groupId>metosin</groupId>

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,6 @@
                  [software.amazon.awssdk/sqs "2.37.3"]
                  [camel-snake-kebab "0.4.0"]
                  [cheshire "6.1.0"]
-                 [clj-time "0.15.2"]
                  [metosin/compojure-api "1.1.14"]
                  [com.stuartsierra/component "0.4.0"]
                  [org.flywaydb/flyway-core "6.0.4"]

--- a/src/liiteri/db.clj
+++ b/src/liiteri/db.clj
@@ -5,9 +5,8 @@
             [liiteri.time-utils :as time]
             [hikari-cp.core :as h])
   (:import (java.sql PreparedStatement)
-           (java.sql Date)
-           (java.sql Timestamp)
-           (org.joda.time DateTime)
+           (java.sql Date Timestamp)
+           (java.time ZonedDateTime)
            (org.postgresql.util PGobject)
            (org.postgresql.jdbc PgArray)))
 
@@ -30,16 +29,16 @@
 
 (extend-protocol jdbc/IResultSetReadColumn
   Date
-  (result-set-read-column [v _ _] (time/sql-date->joda-time v))
+  (result-set-read-column [v _ _] (time/sql-date->date-time v))
 
   Timestamp
-  (result-set-read-column [v _ _] (time/sql-time->joda-time v))
+  (result-set-read-column [v _ _] (time/sql-time->date-time v))
 
   PgArray
   (result-set-read-column [v _ _]
     (vec (.getArray v))))
 
-(extend-type DateTime
+(extend-type ZonedDateTime
   jdbc/ISQLParameter
   (set-parameter [v ^PreparedStatement stmt idx]
     (.setTimestamp stmt idx (time/date-time->sql-time v))))

--- a/src/liiteri/db.clj
+++ b/src/liiteri/db.clj
@@ -2,7 +2,7 @@
   (:require [com.stuartsierra.component :as component]
             [cheshire.core :as json]
             [clojure.java.jdbc :as jdbc]
-            [clj-time.coerce :as c]
+            [liiteri.time-utils :as time]
             [hikari-cp.core :as h])
   (:import (java.sql PreparedStatement)
            (java.sql Date)
@@ -30,10 +30,10 @@
 
 (extend-protocol jdbc/IResultSetReadColumn
   Date
-  (result-set-read-column [v _ _] (c/from-sql-date v))
+  (result-set-read-column [v _ _] (time/sql-date->joda-time v))
 
   Timestamp
-  (result-set-read-column [v _ _] (c/from-sql-time v))
+  (result-set-read-column [v _ _] (time/sql-time->joda-time v))
 
   PgArray
   (result-set-read-column [v _ _]
@@ -42,7 +42,7 @@
 (extend-type DateTime
   jdbc/ISQLParameter
   (set-parameter [v ^PreparedStatement stmt idx]
-    (.setTimestamp stmt idx (c/to-sql-time v))))
+    (.setTimestamp stmt idx (time/date-time->sql-time v))))
 
 (defonce datasource (atom nil))
 

--- a/src/liiteri/db/db_utils.clj
+++ b/src/liiteri/db/db_utils.clj
@@ -1,9 +1,8 @@
 (ns liiteri.db.db-utils
   (:require [camel-snake-kebab.core :as t]
             [camel-snake-kebab.extras :as e]
-            [clj-time.coerce :as c]
-            [clojure.walk])
-  (:import [java.sql Timestamp]))
+            [liiteri.time-utils :as time-utils]
+            [clojure.walk]))
 
 (defn kwd->snake-case [data]
   {:pre [(map? data)]}
@@ -12,11 +11,6 @@
 (defn kwd->kebab-case [data]
   {:pre [(map? data)]}
   (e/transform-keys t/->kebab-case-keyword data))
-
-(defn- sql-date->joda-time [x]
-  (cond-> x
-          (instance? Timestamp x)
-          (c/from-sql-date)))
 
 (defn- transform-values [data t]
   (clojure.walk/prewalk (fn [x]
@@ -28,4 +22,4 @@
 (defn unwrap-data [data]
   (some-> data
           kwd->kebab-case
-          (transform-values sql-date->joda-time)))
+          (transform-values time-utils/sql-time->joda-time)))

--- a/src/liiteri/db/db_utils.clj
+++ b/src/liiteri/db/db_utils.clj
@@ -22,4 +22,4 @@
 (defn unwrap-data [data]
   (some-> data
           kwd->kebab-case
-          (transform-values time-utils/sql-time->joda-time)))
+          (transform-values time-utils/sql-time->date-time)))

--- a/src/liiteri/db/file_metadata_store.clj
+++ b/src/liiteri/db/file_metadata_store.clj
@@ -1,5 +1,5 @@
 (ns liiteri.db.file-metadata-store
-  (:require [clj-time.core :as t]
+  (:require [liiteri.time-utils :as time]
             [clojure.string :as string]
             [liiteri.db.db-utils :as db-utils]
             [schema.core :as s]
@@ -102,7 +102,7 @@
        (reduce (fn pick-latest-metadata [result {:keys [key uploaded] :as metadata}]
                  (cond-> result
                          (or (not (contains? result key))
-                             (t/before? (get-in result [key :uploaded]) uploaded))
+                             (time/before? (get-in result [key :uploaded]) uploaded))
                          (assoc key metadata)))
                {})
        ((fn [metadata]

--- a/src/liiteri/file_cleaner.clj
+++ b/src/liiteri/file_cleaner.clj
@@ -2,11 +2,10 @@
     (:require [chime :as c]
               [clojure.core.async :as a]
               [clojure.java.jdbc :as jdbc]
-              [clj-time.core :as t]
-              [clj-time.periodic :as p]
               [com.stuartsierra.component :as component]
               [liiteri.db.file-metadata-store :as metadata-store]
               [liiteri.files.file-store :as file-store]
+              [liiteri.time-utils :as time]
               [taoensso.timbre :as log]))
 
 (defn- clean-file [conn storage-engine file process-name delete-file-permanently?]
@@ -78,7 +77,7 @@
     (let [poll-interval (if clean-deleted-files?
                           (get-in config [:file-delete-cleaner :poll-interval-seconds])
                           (get-in config [:file-cleaner :poll-interval-seconds]))
-          times         (c/chime-ch (p/periodic-seq (t/now) (t/seconds poll-interval))
+          times         (c/chime-ch (time/periodic-seq poll-interval)
                                     {:ch (a/chan (a/sliding-buffer 1))})]
       (if clean-deleted-files?
         (clean-deleted-files db storage-engine times)

--- a/src/liiteri/local.clj
+++ b/src/liiteri/local.clj
@@ -1,10 +1,9 @@
 (ns liiteri.local
   (:require [chime :as c]
             [clojure.core.async :as a]
-            [clj-time.core :as t]
-            [clj-time.periodic :as p]
             [com.stuartsierra.component :as component]
             [environ.core :refer [env]]
+            [liiteri.time-utils :as time]
             [taoensso.timbre :as log]
             [cheshire.core :as json]
             [clojure.java.io :as io]
@@ -107,7 +106,7 @@
         (let [sqs-client (get-sqs-client)
               request-queue-url (ensure-queue-exists sqs-client (get-scan-request-queue-name config))
               result-queue-url (ensure-queue-exists sqs-client (get-scan-result-queue-name config))
-              times (c/chime-ch (p/periodic-seq (t/now) (t/seconds 1))
+              times (c/chime-ch (time/periodic-seq 1)
                                 {:ch (a/chan (a/sliding-buffer 1))})]
              (ensure-bucket-exists (:s3-client s3-client) (get-bucket-name config))
              (a/go-loop []

--- a/src/liiteri/schema.clj
+++ b/src/liiteri/schema.clj
@@ -1,7 +1,7 @@
 (ns liiteri.schema
   (:require [ring.swagger.upload]
             [schema.core :as s])
-  (:import [org.joda.time DateTime]))
+  (:import (java.time ZonedDateTime)))
 
 ;; This is the public schema of Liiteri API
 
@@ -9,8 +9,8 @@
   {:key          s/Str
    :content-type s/Str
    :size         s/Int
-   :uploaded     DateTime
-   :deleted      (s/maybe DateTime)})
+   :uploaded     ZonedDateTime
+   :deleted      (s/maybe ZonedDateTime)})
 
 (s/defschema File
   {:key               s/Str
@@ -20,8 +20,8 @@
    :page-count        (s/maybe s/Int)
    :virus-scan-status s/Str
    :final             s/Bool
-   :uploaded          DateTime
-   :deleted           (s/maybe DateTime)
+   :uploaded          ZonedDateTime
+   :deleted           (s/maybe ZonedDateTime)
    :preview-status    (s/enum "not_supported" "not_generated" "started" "finished" "error")
    :previews          [Preview]
    (s/optional-key :content-disposition) (s/maybe s/Str)})

--- a/src/liiteri/time_utils.clj
+++ b/src/liiteri/time_utils.clj
@@ -32,7 +32,7 @@
 
 (defonce timezone-utc (ZoneId/of "UTC"))
 (defn formatter-for-utc [fmt-str] (-> (DateTimeFormatter/ofPattern fmt-str) (.withZone timezone-utc)))
-(defonce formatter-utc-with-millis (formatter-for-utc "yyyy-MM-dd'T'HH:mm:ss:SSSX"))
+(defonce formatter-utc-with-millis (formatter-for-utc "yyyy-MM-dd'T'HH:mm:ss.SSSX"))
 
 (cheshire/add-encoder ZonedDateTime
                       (fn [c jsonGenerator]

--- a/src/liiteri/time_utils.clj
+++ b/src/liiteri/time_utils.clj
@@ -1,25 +1,25 @@
 (ns liiteri.time-utils
-  (:require [clj-time.coerce :as coerce]
-            [clj-time.core :as time])
   (:import (java.sql Timestamp)
-           (org.joda.time DateTime Instant)))
+           (java.time Instant ZoneId ZonedDateTime)))
+
+(defonce timezone-fi (ZoneId/of "Europe/Helsinki"))
 
 (defn current-time-millis []
-  (.getMillis (Instant/now)))
+  (.toEpochMilli (Instant/now)))
 
-(defn date-time->sql-time ^Timestamp [date-time]
-  (coerce/to-sql-time date-time))
+(defn date-time->sql-time ^Timestamp [^ZonedDateTime date-time]
+  (Timestamp/from (.toInstant date-time)))
 
-(defn sql-time->joda-time ^DateTime [x]
+(defn sql-time->date-time ^ZonedDateTime [x]
   (cond-> x
           (instance? Timestamp x)
-          (coerce/from-sql-date)))
+          (-> (.toInstant) (ZonedDateTime/ofInstant timezone-fi))))
 
-(defn sql-date->joda-time ^DateTime [x]
-  (coerce/from-sql-date x))
+(defn sql-date->date-time ^ZonedDateTime [x]
+  (-> x (.toLocalDate) (.atStartOfDay timezone-fi)))
 
-(defn before? [this that]
-  (time/before? this that))
+(defn before? [^ZonedDateTime this that]
+  (.isBefore this that))
 
 (defn periodic-seq
   "Päättymätön sarja aikaleimoja alkaen nykyhetkestä aina interval-seconds sekunnin välein, millisekunteina"

--- a/src/liiteri/time_utils.clj
+++ b/src/liiteri/time_utils.clj
@@ -39,4 +39,4 @@
                       (fn [c jsonGenerator]
                         (.writeString jsonGenerator (.format formatter-utc-with-millis c))))
 
-(defmethod json-schema/convert-class java.time.ZonedDateTime [_ _] {:type "string" :format "date"})
+(defmethod json-schema/convert-class java.time.ZonedDateTime [_ _] {:type "string" :format "date-time"})

--- a/src/liiteri/time_utils.clj
+++ b/src/liiteri/time_utils.clj
@@ -1,6 +1,7 @@
 (ns liiteri.time-utils
   (:require [cheshire.factory]
-            [cheshire.generate :as cheshire])
+            [cheshire.generate :as cheshire]
+            [ring.swagger.json-schema :as json-schema])
   (:import (java.sql Timestamp)
            (java.time Instant ZoneId ZonedDateTime)
            (java.time.format DateTimeFormatter)))
@@ -37,3 +38,5 @@
 (cheshire/add-encoder ZonedDateTime
                       (fn [c jsonGenerator]
                         (.writeString jsonGenerator (.format formatter-utc-with-millis c))))
+
+(defmethod json-schema/convert-class java.time.ZonedDateTime [_ _] {:type "string" :format "date"})

--- a/src/liiteri/time_utils.clj
+++ b/src/liiteri/time_utils.clj
@@ -1,6 +1,9 @@
 (ns liiteri.time-utils
+  (:require [cheshire.factory]
+            [cheshire.generate :as cheshire])
   (:import (java.sql Timestamp)
-           (java.time Instant ZoneId ZonedDateTime)))
+           (java.time Instant ZoneId ZonedDateTime)
+           (java.time.format DateTimeFormatter)))
 
 (defonce timezone-fi (ZoneId/of "Europe/Helsinki"))
 
@@ -26,3 +29,11 @@
   [interval-seconds]
   (let [a (* interval-seconds 1000)]
     (iterate (partial + a) (current-time-millis))))
+
+(defonce timezone-utc (ZoneId/of "UTC"))
+(defn formatter-for-utc [fmt-str] (-> (DateTimeFormatter/ofPattern fmt-str) (.withZone timezone-utc)))
+(defonce formatter-utc-with-millis (formatter-for-utc "yyyy-MM-dd'T'HH:mm:ss:SSSX"))
+
+(cheshire/add-encoder ZonedDateTime
+                      (fn [c jsonGenerator]
+                        (.writeString jsonGenerator (.format formatter-utc-with-millis c))))

--- a/src/liiteri/time_utils.clj
+++ b/src/liiteri/time_utils.clj
@@ -1,0 +1,28 @@
+(ns liiteri.time-utils
+  (:require [clj-time.coerce :as coerce]
+            [clj-time.core :as time])
+  (:import (java.sql Timestamp)
+           (org.joda.time DateTime Instant)))
+
+(defn current-time-millis []
+  (.getMillis (Instant/now)))
+
+(defn date-time->sql-time ^Timestamp [date-time]
+  (coerce/to-sql-time date-time))
+
+(defn sql-time->joda-time ^DateTime [x]
+  (cond-> x
+          (instance? Timestamp x)
+          (coerce/from-sql-date)))
+
+(defn sql-date->joda-time ^DateTime [x]
+  (coerce/from-sql-date x))
+
+(defn before? [this that]
+  (time/before? this that))
+
+(defn periodic-seq
+  "Päättymätön sarja aikaleimoja alkaen nykyhetkestä aina interval-seconds sekunnin välein, millisekunteina"
+  [interval-seconds]
+  (let [a (* interval-seconds 1000)]
+    (iterate (partial + a) (current-time-millis))))

--- a/test/liiteri/file_cleaner_test.clj
+++ b/test/liiteri/file_cleaner_test.clj
@@ -1,14 +1,14 @@
 (ns liiteri.file-cleaner-test
-  (:require [clj-time.core :as t]
-            [clojure.test :refer :all]
+  (:require [clojure.test :refer :all]
             [liiteri.core :as system]
             [liiteri.files.file-store :as file-store]
             [liiteri.db.file-metadata-store :as metadata-store]
             [liiteri.db.test-metadata-store :as test-metadata-store]
             [liiteri.file-cleaner :as cleaner]
             [liiteri.test-utils :as u])
-  (:import [java.util UUID]
-           [java.sql Timestamp]))
+  (:import (java.time ZonedDateTime)
+           (java.util UUID)
+           (java.sql Timestamp)))
 
 (def system (atom (system/new-system true)))
 (def metadata (atom nil))
@@ -50,10 +50,10 @@
   (let [db             (:db @system)
         storage-engine (:storage-engine @system)
         config         (:config @system)
-        uploaded       (-> (t/now)
-                           (t/minus (t/months 1))
-                           (.getMillis)
-                           (Timestamp.))]
+        uploaded       (-> (ZonedDateTime/now)
+                           (.minusMonths 1)
+                           (.toInstant)
+                           (Timestamp/from))]
     (init-test-file uploaded)
     (#'cleaner/clean-files db storage-engine)
     (let [metadata (test-metadata-store/get-metadata-for-tests [(:key @metadata)] {:connection db})]
@@ -68,9 +68,9 @@
   (let [db             (:db @system)
         storage-engine (:storage-engine @system)
         config         (:config @system)
-        uploaded       (-> (t/now)
-                           (.getMillis)
-                           (Timestamp.))]
+        uploaded       (-> (ZonedDateTime/now)
+                           (.toInstant)
+                           (Timestamp/from))]
     (init-test-file uploaded)
     (#'cleaner/clean-files db storage-engine)
     (let [metadata (test-metadata-store/get-metadata-for-tests [(:key @metadata)] {:connection db})]

--- a/test/liiteri/file_store_test.clj
+++ b/test/liiteri/file_store_test.clj
@@ -1,14 +1,14 @@
 (ns liiteri.file-store-test
-  (:require [clj-time.core :as t]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [clojure.test :refer :all]
             [liiteri.core :as system]
             [liiteri.db.file-metadata-store :as metadata-store]
             [liiteri.db.test-metadata-store :as test-metadata-store]
             [liiteri.files.file-store :as file-store]
             [liiteri.test-utils :as u])
-  (:import [java.util UUID]
-           [java.sql Timestamp]))
+  (:import (java.time ZonedDateTime)
+           (java.util UUID)
+           (java.sql Timestamp)))
 
 (def system (atom (system/new-system false)))
 (def metadata1 (atom nil))
@@ -43,14 +43,14 @@
         origin-system "Test-system"
         conn {:connection (:db @system)}
         store (:storage-engine @system)
-        uploaded (-> (t/now)
-                     (t/minus (t/months 1))
-                     (.getMillis)
-                     (Timestamp.))
-        deleted (-> (t/now)
-                    (t/minus (t/days 1))
-                    (.getMillis)
-                    (Timestamp.))]
+        uploaded (-> (ZonedDateTime/now)
+                     (.minusMonths 1)
+                     (.toInstant)
+                     (Timestamp/from))
+        deleted (-> (ZonedDateTime/now)
+                    (.minusDays 1)
+                    (.toInstant)
+                    (Timestamp/from))]
     (file-store/create-file-from-bytearray store (.getBytes "test file1") file-key1)
     (file-store/create-file-from-bytearray store (.getBytes "test file2") file-key2)
     (file-store/create-file-from-bytearray store (.getBytes "test file3") file-key3)

--- a/test/liiteri/mime_fixer_test.clj
+++ b/test/liiteri/mime_fixer_test.clj
@@ -6,9 +6,9 @@
             [liiteri.fixtures :refer :all]
             [liiteri.test-utils :as u]
             [com.stuartsierra.component :as component]
-            [clj-time.core :as t]
             [clojure.test :refer :all])
-  (:import [java.sql Timestamp]))
+  (:import (java.sql Timestamp)
+           (java.time Instant)))
 
 (def system (atom (system/new-system true {})))
 
@@ -24,9 +24,8 @@
   (let [store (u/new-in-memory-store)
         conn  {:connection (:db @system)}]
     (doseq [{:keys [mangled-filename filename file-object content-type size]} mangled-extension-files]
-      (let [uploaded  (-> (t/now)
-                          (.getMillis)
-                          (Timestamp.))
+      (let [uploaded  (-> (Instant/now)
+                          (Timestamp/from))
             file-spec {:key              filename
                        :filename         mangled-filename
                        :content-type     nil

--- a/test/liiteri/preview/preview_generator_test.clj
+++ b/test/liiteri/preview/preview_generator_test.clj
@@ -7,10 +7,9 @@
             [liiteri.fixtures :as fixtures]
             [liiteri.test-utils :as u]
             [liiteri.preview.preview-generator :as preview-generator]
-            [com.stuartsierra.component :as component]
-            [clj-time.core :as t]
-            [taoensso.timbre :as log])
-  (:import [java.sql Timestamp]
+            [com.stuartsierra.component :as component])
+  (:import (java.sql Timestamp)
+           (java.time Instant)
            (java.util.concurrent Executors)))
 
 (def system (atom (system/new-system true {})))
@@ -29,7 +28,7 @@
   (is (= 1 (count (:previews file-metadata))))
 
   (is (= 1 (count previews)))
-  (is (= (str (:filename file-metadata) ".0" (-> (first previews) :key))))
+  (is (= (str (:filename file-metadata) ".0") (-> (first previews) :key)))
   (is (= "image/png" (-> (first previews) :content-type)))
   (is (< 0 (-> (first previews) :size))))
 
@@ -51,9 +50,8 @@
   (let [store (u/new-in-memory-store)
         conn  {:connection (:db @system)}]
     (doseq [{:keys [filename file-object content-type size]} fixtures/ok-files]
-      (let [uploaded  (-> (t/now)
-                          (.getMillis)
-                          (Timestamp.))
+      (let [uploaded  (-> (Instant/now)
+                          (Timestamp/from))
             origin-system "Test-system"
             origin-reference "1.2.246.562.11.000000000000000000001"
             file-spec {:key              filename
@@ -79,9 +77,8 @@
   (let [store (u/new-in-memory-store)
         conn  {:connection (:db @system)}]
     (doseq [{:keys [filename file-object content-type size]} fixtures/not-ok-preview-files]
-      (let [uploaded  (-> (t/now)
-                          (.getMillis)
-                          (Timestamp.))
+      (let [uploaded  (-> (Instant/now)
+                          (Timestamp/from))
             origin-system "Test-system"
             origin-reference "1.2.246.562.11.000000000000000000001"
             file-spec {:key              filename
@@ -105,9 +102,8 @@
   (let [store (u/new-in-memory-store)
         conn  {:connection (:db @system)}]
     (doseq [{:keys [filename file-object content-type size]} (take 2 fixtures/ok-files)]
-      (let [uploaded  (-> (t/now)
-                          (.getMillis)
-                          (Timestamp.))
+      (let [uploaded  (-> (Instant/now)
+                          (Timestamp/from))
             origin-system "Test-system"
             origin-reference "1.2.246.562.11.000000000000000000001"
             file-spec {:key             filename

--- a/test/liiteri/time_utils_test.clj
+++ b/test/liiteri/time_utils_test.clj
@@ -1,0 +1,62 @@
+(ns liiteri.time-utils-test
+  (:require [clojure.test :refer :all]
+            [liiteri.time-utils :as time-utils])
+  (:import (java.sql Date Timestamp)
+           (java.time LocalDate Instant)
+           (org.joda.time DateTime )))
+
+(defonce exact-time 1770112704312)
+
+(defn- breakdown
+  "Palauttaa ajan jaoteltuna osiinsa [vuosi kk pv t m s milli vyöhyke]"
+  [^DateTime time]
+  [(.getYear time)
+   (.getMonthOfYear time)
+   (.getDayOfMonth time)
+   (.getHourOfDay time)
+   (.getMinuteOfHour time)
+   (.getSecondOfMinute time)
+   (.getMillisOfSecond time)
+   (-> time .getZone .getID)])
+
+(defn- parse-test-sql-time ^Timestamp [date-str]
+  (Timestamp/from (Instant/parse date-str)))
+
+(defn- parse-test-sql-date ^Date [date-str]
+  (Date/valueOf (LocalDate/parse date-str)))
+
+(deftest date-time->sql-time
+  (testing "returns correct timestamp"
+    (is (= exact-time (.getTime (time-utils/date-time->sql-time (DateTime/parse "2026-02-03T11:58:24.312+02:00")))))))
+
+(deftest sql-time->joda-time
+  (testing "returns correct date time when given a timestamp"
+    (is (= [2025 1 1 15 42 31 0 "UTC"] (breakdown (time-utils/sql-time->joda-time (parse-test-sql-time "2025-01-01T15:42:31Z")))))
+    (is (= [2025 1 1 15 42 31 134 "UTC"] (breakdown (time-utils/sql-time->joda-time (parse-test-sql-time "2025-01-01T15:42:31.134Z"))))))
+  (testing "returns back the parameter when given an SQL date"
+    (let [param (parse-test-sql-date "2025-01-01")]
+      (is (= param (time-utils/sql-time->joda-time param)))))
+  (testing "returns nil when given nil"
+    (is (= nil (time-utils/sql-time->joda-time nil)))))
+
+(deftest sql-date->joda-time
+  (testing "returns the midnight timestamp converted to UTC when given an SQL date"
+    (is (= [2024 12 31 22 0 0 0 "UTC"] (breakdown (time-utils/sql-date->joda-time (parse-test-sql-date "2025-01-01")))))
+    (is (= [2024 12 30 22 0 0 0 "UTC"] (breakdown (time-utils/sql-date->joda-time (parse-test-sql-date "2024-12-31")))))))
+
+(deftest before?
+  (let [first (DateTime/parse "2024-12-31T13:00:00")
+        second (DateTime/parse "2025-01-01T13:00:00")]
+    (testing "returns true only when this is strictly before that"
+      (is (= true (time-utils/before? first second)))
+      (is (= false (time-utils/before? second first)))
+      (is (= false (time-utils/before? first first))))))
+
+(deftest periodic-seq
+  (with-redefs [time-utils/current-time-millis (constantly exact-time)]
+    (testing "starts at the current time"
+      (is (= exact-time (first (time-utils/periodic-seq 60)))))
+    (testing "increases with seconds with each element"
+      (is (= (+ exact-time 60000) (nth (time-utils/periodic-seq 60) 1)))
+      (is (= (+ exact-time 120000) (nth (time-utils/periodic-seq 60) 2)))
+      (is (= (+ exact-time 180000) (nth (time-utils/periodic-seq 60) 3))))))

--- a/test/liiteri/time_utils_test.clj
+++ b/test/liiteri/time_utils_test.clj
@@ -1,23 +1,22 @@
 (ns liiteri.time-utils-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing]]
             [liiteri.time-utils :as time-utils])
   (:import (java.sql Date Timestamp)
-           (java.time LocalDate Instant)
-           (org.joda.time DateTime )))
+           (java.time LocalDate Instant ZonedDateTime)))
 
 (defonce exact-time 1770112704312)
 
 (defn- breakdown
-  "Palauttaa ajan jaoteltuna osiinsa [vuosi kk pv t m s milli vyöhyke]"
-  [^DateTime time]
+  "Palauttaa ajan pilkottuna osiin: [vuosi kk pv t m s milli vyöhyke]"
+  [^ZonedDateTime time]
   [(.getYear time)
-   (.getMonthOfYear time)
+   (.getMonthValue time)
    (.getDayOfMonth time)
-   (.getHourOfDay time)
-   (.getMinuteOfHour time)
-   (.getSecondOfMinute time)
-   (.getMillisOfSecond time)
-   (-> time .getZone .getID)])
+   (.getHour time)
+   (.getMinute time)
+   (.getSecond time)
+   (-> time .getNano (/ 1000000) int)
+   (-> time .getZone .getId)])
 
 (defn- parse-test-sql-time ^Timestamp [date-str]
   (Timestamp/from (Instant/parse date-str)))
@@ -27,26 +26,26 @@
 
 (deftest date-time->sql-time
   (testing "returns correct timestamp"
-    (is (= exact-time (.getTime (time-utils/date-time->sql-time (DateTime/parse "2026-02-03T11:58:24.312+02:00")))))))
+    (is (= exact-time (.getTime (time-utils/date-time->sql-time (ZonedDateTime/parse "2026-02-03T11:58:24.312+02:00")))))))
 
-(deftest sql-time->joda-time
+(deftest sql-time->date-time
   (testing "returns correct date time when given a timestamp"
-    (is (= [2025 1 1 15 42 31 0 "UTC"] (breakdown (time-utils/sql-time->joda-time (parse-test-sql-time "2025-01-01T15:42:31Z")))))
-    (is (= [2025 1 1 15 42 31 134 "UTC"] (breakdown (time-utils/sql-time->joda-time (parse-test-sql-time "2025-01-01T15:42:31.134Z"))))))
+    (is (= [2025 1 1 17 42 31 0 "Europe/Helsinki"] (breakdown (time-utils/sql-time->date-time (parse-test-sql-time "2025-01-01T15:42:31Z")))))
+    (is (= [2025 1 1 17 42 31 134 "Europe/Helsinki"] (breakdown (time-utils/sql-time->date-time (parse-test-sql-time "2025-01-01T15:42:31.134Z"))))))
   (testing "returns back the parameter when given an SQL date"
     (let [param (parse-test-sql-date "2025-01-01")]
-      (is (= param (time-utils/sql-time->joda-time param)))))
+      (is (= param (time-utils/sql-time->date-time param)))))
   (testing "returns nil when given nil"
-    (is (= nil (time-utils/sql-time->joda-time nil)))))
+    (is (= nil (time-utils/sql-time->date-time nil)))))
 
-(deftest sql-date->joda-time
-  (testing "returns the midnight timestamp converted to UTC when given an SQL date"
-    (is (= [2024 12 31 22 0 0 0 "UTC"] (breakdown (time-utils/sql-date->joda-time (parse-test-sql-date "2025-01-01")))))
-    (is (= [2024 12 30 22 0 0 0 "UTC"] (breakdown (time-utils/sql-date->joda-time (parse-test-sql-date "2024-12-31")))))))
+(deftest sql-date->date-time
+  (testing "returns the midnight timestamp when given an SQL date"
+    (is (= [2025 01 01 00 0 0 0 "Europe/Helsinki"] (breakdown (time-utils/sql-date->date-time (parse-test-sql-date "2025-01-01")))))
+    (is (= [2024 12 31 00 0 0 0 "Europe/Helsinki"] (breakdown (time-utils/sql-date->date-time (parse-test-sql-date "2024-12-31")))))))
 
 (deftest before?
-  (let [first (DateTime/parse "2024-12-31T13:00:00")
-        second (DateTime/parse "2025-01-01T13:00:00")]
+  (let [first (ZonedDateTime/parse "2024-12-31T13:00:00Z")
+        second (ZonedDateTime/parse "2025-01-01T13:00:00Z")]
     (testing "returns true only when this is strictly before that"
       (is (= true (time-utils/before? first second)))
       (is (= false (time-utils/before? second first)))


### PR DESCRIPTION
Ensin refaktoroidaan aikatoiminnot yhteen namespaceen ja testataan ne. Sitten luovutaan Joda-timesta ja  clj-timesta ja vaihdetaan ne java-timeen.